### PR TITLE
Fixed `Issue: #7`: Video Duration `BUG`

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,7 +104,7 @@ high.addEventListener("click", muter);
 low.addEventListener("click", muter);
 
 //for volume
-volumeRange.addEventListener("input", () => {
+volumeRange.addEventListener("input", () => {     
   //for converting % to decimal values since video.volume would accept decimals only
   let volumeValue = volumeRange.value / 100;
   myVideo.volume = volumeValue;
@@ -186,21 +186,24 @@ screenCompress.addEventListener(
   })
 );
 
-//Format time
+// Format time
 const timeFormatter = (timeInput) => {
-  let minute = Math.floor(timeInput / 60);
-  minute = minute < 10 ? "0" + minute : minute;
-  let second = Math.floor(timeInput % 60);
-  second = second < 10 ? "0" + second : second;
-  return `${minute}:${second}`;
+  let minutes = Math.floor(timeInput / 60);
+  let seconds = Math.floor(timeInput % 60);
+  const formattedTime = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  return formattedTime;
 };
 
-//Update progress every second
+// Update progress and time every second
 setInterval(() => {
   currentTimeRef.innerHTML = timeFormatter(myVideo.currentTime);
-  currentProgress.style.width =
-    (myVideo.currentTime / myVideo.duration.toFixed(3)) * 100 + "%";
+  const duration = myVideo.duration;
+  if (!isNaN(duration)) {
+    maxDuration.innerText = timeFormatter(duration);
+    currentProgress.style.width = ((myVideo.currentTime / duration) * 100) + "%";
+  }
 }, 1000);
+
 
 //update timer
 myVideo.addEventListener("timeupdate", () => {


### PR DESCRIPTION
## Fixed the `BUG` mentioned in Issue #7
- To fix the issue where the total time of the video is always shown as 00:00, we need to update the way we calculate and display the total duration of the video.
- We'll also make some modifications to the `setInterval function` to ensure that the duration is displayed correctly

Here's the updated code:
```javascript
const timeFormatter = (timeInput) => {    // Format time
  const formattedTime = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`; # displaying the time properly
};
// Update progress and time every second
setInterval(() => {
    currentProgress.style.width = ((myVideo.currentTime / duration) * 100) + "%"; # calculating the total duration
  }
```

Review changes made to the **javascript**.